### PR TITLE
Fix casting of values

### DIFF
--- a/spec/polo_spec.rb
+++ b/spec/polo_spec.rb
@@ -13,8 +13,14 @@ describe Polo do
   end
 
   it 'generates insert queries for dependencies' do
-    turkey_insert        = "INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`) VALUES (1, 'Turkey Sandwich', NULL, 1)"
-    cheese_burger_insert = "INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`) VALUES (2, 'Cheese Burger', NULL, 1)"
+    if ActiveRecord::VERSION::STRING.start_with?('4.2')
+      serialized_nil = "NULL"
+    else
+      serialized_nil = "'null'"
+    end
+
+    turkey_insert        = "INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`, `metadata`) VALUES (1, 'Turkey Sandwich', NULL, 1, #{serialized_nil})"
+    cheese_burger_insert = "INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`, `metadata`) VALUES (2, 'Cheese Burger', NULL, 1, #{serialized_nil})"
 
     inserts = Polo.explore(AR::Chef, 1, [:recipes])
 
@@ -36,7 +42,7 @@ describe Polo do
     expect(inserts).to include(two_cheeses)
   end
 
-  it 'generates insersts for many to many relationships' do
+  it 'generates inserts for many to many relationships' do
     many_to_many_inserts = [
       "INSERT INTO `recipes_ingredients` (`id`, `recipe_id`, `ingredient_id`) VALUES (1, 1, 1)",
       "INSERT INTO `recipes_ingredients` (`id`, `recipe_id`, `ingredient_id`) VALUES (2, 1, 2)",

--- a/spec/sql_translator_spec.rb
+++ b/spec/sql_translator_spec.rb
@@ -16,6 +16,12 @@ describe Polo::SqlTranslator do
     expect(netto_to_sql).to eq(insert_netto)
   end
 
+  it 'encodes serialized fields correctly' do
+    recipe = AR::Recipe.create(title: 'Polenta', metadata: { quality: 'ok' })
+    recipe_to_sql = Polo::SqlTranslator.new(recipe).to_sql.first
+    expect(recipe_to_sql).to include(%q{'{"quality":"ok"}'}) # JSON, not YAML
+  end
+
   describe "options" do
     describe "on_duplicate: :ignore" do
       it 'uses INSERT IGNORE as opposed to regular inserts' do

--- a/spec/support/activerecord_models.rb
+++ b/spec/support/activerecord_models.rb
@@ -3,6 +3,8 @@ module AR
     belongs_to :chef
     has_many :recipes_ingredients
     has_many :ingredients, through: :recipes_ingredients
+
+    serialize :metadata, JSON
   end
 
   class Ingredient < ActiveRecord::Base

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -3,6 +3,7 @@ ActiveRecord::Schema.define do
     t.column :title, :string
     t.column :num_steps, :integer
     t.column :chef_id, :integer
+    t.column :metadata, :text
   end
 
   create_table :ingredients, force: true do |t|


### PR DESCRIPTION
We were getting by with just calling `connection.quote` on values to be
inserted, which isn't sufficient for some kinds of columns (e.g.,
serialized ones).
