### PR TITLE
Some ActiveRecord classes do not use id as the primary key

### DIFF
--- a/lib/polo/collector.rb
+++ b/lib/polo/collector.rb
@@ -15,7 +15,7 @@ module Polo
     #
     def collect
       ActiveSupport::Notifications.subscribed(collector, 'sql.active_record') do
-        base_finder = @base_class.includes(@dependency_tree).where(id: @id)
+        base_finder = @base_class.includes(@dependency_tree).where(@base_class.primary_key => @id)
         collect_sql(@base_class, base_finder.to_sql)
         base_finder.to_a
       end

--- a/spec/polo_spec.rb
+++ b/spec/polo_spec.rb
@@ -12,6 +12,12 @@ describe Polo do
     expect(exp).to include(insert)
   end
 
+  it 'generates an insert query for the objects with non-standard primary keys' do
+    exp = Polo.explore(AR::Person, 1)
+    insert = "INSERT INTO `people` (`ssn`, `name`) VALUES (1, 'John Doe')"
+    expect(exp).to include(insert)
+  end
+
   it 'generates insert queries for dependencies' do
     if ActiveRecord::VERSION::STRING.start_with?('4.2')
       serialized_nil = "NULL"

--- a/spec/support/activerecord_models.rb
+++ b/spec/support/activerecord_models.rb
@@ -29,4 +29,8 @@ module AR
     has_many :ingredients, through: :recipes
     has_one  :restaurant, foreign_key: 'owner_id'
   end
+
+  class Person < ActiveRecord::Base
+    self.primary_key = :ssn
+  end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -12,5 +12,7 @@ module TestData
         r.ingredients.create(name: 'Cheese', quantity: '2 slices')
       end
     end
+
+    AR::Person.create(name: 'John Doe')
   end
 end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -31,4 +31,8 @@ ActiveRecord::Schema.define do
     t.column :value, :string
     t.column :restaurant_id, :integer
   end
+
+  create_table :people, primary_key: :ssn, force: true do |t|
+    t.column :name, :string
+  end
 end


### PR DESCRIPTION
One of the old Rails apps I maintain uses a legacy database, where the primary key of the corresponding table is not named *id*.

This pull request will make the gem usable on those kinds of projects.