### PR TITLE
Add a CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+## Master (current)
+
+### Breaking Changes
+
+- None
+
+### Added
+
+- [#8](https://github.com/IFTTT/polo/pull/8) Global settings
+- [#17](https://github.com/IFTTT/polo/pull/17) Using random generator instead of character shuffle for data obfuscation
+- [#18](https://github.com/IFTTT/polo/pull/18) Add a CHANGELOG
+
+### Fixed
+
+- Typo fixes on the README: [#9](https://github.com/IFTTT/polo/pull/9), [#10](https://github.com/IFTTT/polo/pull/10)
+- [#11]() Some ActiveRecord classes do not use id as the primary key
+
+## 0.1.0
+
+### Breaking Changes
+
+- None
+
+### Added
+
+- [#2](https://github.com/IFTTT/polo/pull/2) Add :ignore and :override options to deal with data collision
+- [#3](https://github.com/IFTTT/polo/pull/3) Add option to obfuscate fields
+- [#4](https://github.com/IFTTT/polo/pull/4) Add intro to Update / Ignore section
+- [#6](https://github.com/IFTTT/polo/pull/6) Set up Appraisal to run specs across Rails 3.2 through 4.2
+
+### Fixed
+
+- [#7](https://github.com/IFTTT/polo/pull/7) Fix casting of values


### PR DESCRIPTION
This PR resolves https://github.com/IFTTT/polo/issues/15.

The `CHANGELOG.md` is based of Papertrail's project: https://github.com/airblade/paper_trail/blob/416ce64c145240466e28a55ae983629aaf1316f5/CHANGELOG.md

Update 1: I'm going to edit this commit after GitHub gives me a PR number to add on Master's "Added" session.

Update 2: @nettofarah, I need you to confirm which PR's are included on the RubyGems version, since I'm only basing this file on timestamps :)