### PR TITLE
Add generic Translator and Reader base

### DIFF
--- a/lib/polo.rb
+++ b/lib/polo.rb
@@ -1,6 +1,10 @@
 require "polo/version"
 require "polo/collector"
+require "polo/importer"
+require "polo/json_reader"
 require "polo/translator"
+require "polo/json_translator"
+require "polo/sql_translator"
 require "polo/configuration"
 
 module Polo
@@ -41,6 +45,10 @@ module Polo
     Traveler.collect(base_class, id, dependencies).translate(defaults)
   end
 
+  def self.read(serialized)
+    Reader.new(serialized).translate(defaults)
+  end
+
 
   # Public: Sets up global settings for Polo
   #
@@ -68,6 +76,16 @@ module Polo
     @configuration || configure
   end
 
+  class Reader
+    def initialize(serialized)
+      @serialized = serialized
+    end
+
+    def translate(configuration=Configuration.new)
+      reads = Importer.new(@serialized, configuration).read
+      Translator.with_reads(reads, configuration).translate
+    end
+  end
 
   class Traveler
 
@@ -81,7 +99,7 @@ module Polo
     end
 
     def translate(configuration=Configuration.new)
-      Translator.new(@selects, configuration).translate
+      Translator.with_selects(@selects, configuration).translate
     end
   end
 end

--- a/lib/polo/configuration.rb
+++ b/lib/polo/configuration.rb
@@ -4,14 +4,15 @@ require 'polo/sql_translator'
 module Polo
 
   class Configuration
-    attr_reader :on_duplicate_strategy, :blacklist, :translator, :reader
+    attr_reader :on_duplicate_strategy, :blacklist, :translator, :reader, :should_pretty_print
 
     def initialize(options={})
-      options = { on_duplicate: nil, obfuscate: {}, use_translator: Polo::SqlTranslator, use_reader: Polo::JsonReader }.merge(options)
+      options = { on_duplicate: nil, obfuscate: {}, use_translator: Polo::SqlTranslator, use_reader: Polo::JsonReader, pretty_print: true }.merge(options)
       on_duplicate(options[:on_duplicate])
       obfuscate(options[:obfuscate])
       use_translator(options[:use_translator])
       use_reader(options[:use_reader])
+      pretty_print(options[:should_pretty_print])
     end
 
     # TODO: document this
@@ -37,6 +38,10 @@ module Polo
 
     def on_duplicate(strategy)
       @on_duplicate_strategy = strategy
+    end
+
+    def pretty_print(should_pretty_print)
+      @should_pretty_print = should_pretty_print
     end
 
     def use_translator(translator)

--- a/lib/polo/configuration.rb
+++ b/lib/polo/configuration.rb
@@ -1,12 +1,17 @@
+require 'polo/json_reader'
+require 'polo/sql_translator'
+
 module Polo
 
   class Configuration
-    attr_reader :on_duplicate_strategy, :blacklist
+    attr_reader :on_duplicate_strategy, :blacklist, :translator, :reader
 
     def initialize(options={})
-      options = { on_duplicate: nil, obfuscate: {} }.merge(options)
-      @on_duplicate_strategy = options[:on_duplicate]
+      options = { on_duplicate: nil, obfuscate: {}, use_translator: Polo::SqlTranslator, use_reader: Polo::JsonReader }.merge(options)
+      on_duplicate(options[:on_duplicate])
       obfuscate(options[:obfuscate])
+      use_translator(options[:use_translator])
+      use_reader(options[:use_reader])
     end
 
     # TODO: document this
@@ -32,6 +37,14 @@ module Polo
 
     def on_duplicate(strategy)
       @on_duplicate_strategy = strategy
+    end
+
+    def use_translator(translator)
+      @translator = translator
+    end
+
+    def use_reader(reader)
+      @reader = reader
     end
   end
 end

--- a/lib/polo/importer.rb
+++ b/lib/polo/importer.rb
@@ -16,7 +16,11 @@ module Polo
     # Public: Translates SELECT queries into INSERTS.
     #
     def read
-      @configuration.reader.new(@serialized, @configuration).read.uniq
+      if @configuration.reader
+        @configuration.reader.new(@serialized, @configuration).read.uniq
+      else
+        @serialized.uniq
+      end
     end
   end
 end

--- a/lib/polo/importer.rb
+++ b/lib/polo/importer.rb
@@ -1,0 +1,22 @@
+require "polo/sql_translator"
+require "polo/configuration"
+
+module Polo
+  class Importer
+
+    # Public: Creates a new Polo::Collector
+    #
+    # selects - An array of SELECT queries
+    #
+    def initialize(serialized, configuration=Configuration.new)
+      @serialized = serialized
+      @configuration = configuration
+    end
+
+    # Public: Translates SELECT queries into INSERTS.
+    #
+    def read
+      @configuration.reader.new(@serialized, @configuration).read.uniq
+    end
+  end
+end

--- a/lib/polo/json_reader.rb
+++ b/lib/polo/json_reader.rb
@@ -1,0 +1,27 @@
+require 'active_record'
+require 'json'
+require 'polo/reader_base'
+
+module Polo
+  class JsonReader < ReaderBase
+    def read
+      tables = active_record_tables
+      data = JSON.parse(@serialized)
+      data.map do |record|
+        klass = tables[record['table']]
+        if klass
+          p_key = klass.primary_key
+          record_instance = klass.new(record['attributes'])
+          record_instance[p_key] = record['attributes'][p_key]
+          record_instance
+        end
+      end
+    end
+
+    private
+
+    def active_record_tables
+      Hash[ActiveRecord::Base.descendants.collect { |c| [c.table_name, c] }]
+    end
+  end
+end

--- a/lib/polo/json_translator.rb
+++ b/lib/polo/json_translator.rb
@@ -5,12 +5,17 @@ require 'polo/translator_base'
 module Polo
   class JsonTranslator < TranslatorBase
     def translation
-      @records.map do |record|
+      data = @records.map do |record|
         {
           table: record.class.table_name,
           attributes: record.attributes
         }
-      end.to_json
+      end
+      if @configuration.should_pretty_print
+        JSON.pretty_generate data
+      else
+        data.to_json
+      end
     end
   end
 end

--- a/lib/polo/json_translator.rb
+++ b/lib/polo/json_translator.rb
@@ -1,0 +1,16 @@
+require 'active_record'
+require 'json'
+require 'polo/translator_base'
+
+module Polo
+  class JsonTranslator < TranslatorBase
+    def translation
+      @records.map do |record|
+        {
+          table: record.class.table_name,
+          attributes: record.attributes
+        }
+      end.to_json
+    end
+  end
+end

--- a/lib/polo/reader_base.rb
+++ b/lib/polo/reader_base.rb
@@ -1,0 +1,15 @@
+require 'polo/configuration'
+
+module Polo
+  class ReaderBase
+
+    def initialize(serialized, configuration=Configuration.new)
+      @serialized = serialized
+      @configuration = configuration
+    end
+
+    def read
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/polo/sql_translator.rb
+++ b/lib/polo/sql_translator.rb
@@ -1,18 +1,11 @@
 require 'active_record'
 require 'polo/configuration'
+require 'polo/translator_base'
 
 module Polo
-  class SqlTranslator
-
-    def initialize(object, configuration=Configuration.new)
-      @record = object
-      @configuration = configuration
-    end
-
-    def to_sql
-      records = Array.wrap(@record)
-
-      sqls = records.map do |record|
+  class SqlTranslator < TranslatorBase
+    def translation
+      sqls = @records.map do |record|
         raw_sql(record)
       end
 
@@ -21,10 +14,10 @@ module Polo
       end
 
       if @configuration.on_duplicate_strategy == :override
-        sqls = on_duplicate_key_update(sqls, records)
+        sqls = on_duplicate_key_update(sqls, @records)
       end
 
-      sqls
+      sqls.uniq
     end
 
     private

--- a/lib/polo/translator.rb
+++ b/lib/polo/translator.rb
@@ -24,7 +24,11 @@ module Polo
     # Public: Translates SELECT queries into INSERTS.
     #
     def translate
-      @configuration.translator.new(instances, @configuration).translation
+      if @configuration.translator
+        @configuration.translator.new(instances, @configuration).translation
+      else
+        instances
+      end
     end
 
     def instances

--- a/lib/polo/translator.rb
+++ b/lib/polo/translator.rb
@@ -32,19 +32,13 @@ module Polo
     end
 
     def instances
-      if @reads
-        @reads
-      else
-        active_record_instances = @selects.flat_map do |select|
-          select[:klass].find_by_sql(select[:sql]).to_a
-        end
+      records = @reads ? @reads : @selects.flat_map { |select| select[:klass].find_by_sql(select[:sql]).to_a }
 
-        if fields = @configuration.blacklist
-          obfuscate!(active_record_instances, fields)
-        end
-
-        active_record_instances
+      if fields = @configuration.blacklist
+        obfuscate!(records, fields)
       end
+
+      records
     end
 
     private

--- a/lib/polo/translator.rb
+++ b/lib/polo/translator.rb
@@ -1,4 +1,3 @@
-require "polo/sql_translator"
 require "polo/configuration"
 
 module Polo
@@ -8,27 +7,40 @@ module Polo
     #
     # selects - An array of SELECT queries
     #
-    def initialize(selects, configuration=Configuration.new)
+    def self.with_selects(selects, configuration=Configuration.new)
+      new(selects, nil, configuration)
+    end
+
+    def self.with_reads(reads, configuration=Configuration.new)
+      new(nil, reads, configuration)
+    end
+
+    def initialize(selects, reads, configuration=Configuration.new)
       @selects = selects
+      @reads = reads
       @configuration = configuration
     end
 
     # Public: Translates SELECT queries into INSERTS.
     #
     def translate
-      SqlTranslator.new(instances, @configuration).to_sql.uniq
+      @configuration.translator.new(instances, @configuration).translation
     end
 
     def instances
-      active_record_instances = @selects.flat_map do |select|
-        select[:klass].find_by_sql(select[:sql]).to_a
-      end
+      if @reads
+        @reads
+      else
+        active_record_instances = @selects.flat_map do |select|
+          select[:klass].find_by_sql(select[:sql]).to_a
+        end
 
-      if fields = @configuration.blacklist
-        obfuscate!(active_record_instances, fields)
-      end
+        if fields = @configuration.blacklist
+          obfuscate!(active_record_instances, fields)
+        end
 
-      active_record_instances
+        active_record_instances
+      end
     end
 
     private

--- a/lib/polo/translator_base.rb
+++ b/lib/polo/translator_base.rb
@@ -1,0 +1,16 @@
+require 'polo/configuration'
+
+module Polo
+  class TranslatorBase
+
+    def initialize(object, configuration=Configuration.new)
+      @record = object
+      @records = Array.wrap(@record)
+      @configuration = configuration
+    end
+
+    def translation
+      raise NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
This adds the idea of having a configurable Translator (transforms AR instances into a serial form) and configurable Reader (transforms serial form back into AR instances).

`SqlTranslator` now inherits from a `TranslatorBase` base class.

A `JsonTranslator` has been also added, which outputs the AR instances into a JSON string with an array of objects of the following structure:
```
{
  "table": (table name of the class of AR instance),
  "attributes": {
    (attributes of the AR instance)
  }
}
```

A `JsonReader` (which inherits from `ReaderBase`) has been added which takes the above format and transforms it into AR instances. It is dependent on the model classes being loaded as it will iterate through `ActiveRecord::Base` descendants to create a mapping of table name to model classes. Since there is no straightforward way of implicitly preload the models (and that behavior may be unideal for certain projects) so I don't believe we should be doing that.

The configuration now accepts the options `:use_reader` and `:use_translator` (they have defaults to `JsonReader` and `SqlTranslator`, respectively).

A new convenience method `Polo#read` has added to read and translate a serialized form of instances.

# Example

```ruby
Polo.configure { use_translator Polo::JsonTranslator }
j = Polo::Traveler.explore(Chef, 2, :recipes)
```

will produce

```json
[
  {
    "table":"chefs",
    "attributes": {
      "id": 2,
      "name": "Andrew"
    }
  },
  {
    "table":"recipes",
    "attributes":
    {
      "id": 3,
      "title": "Vegemite Sandwich",
      "num_steps": null,
      "chef_id": 2
    }
  },
  {
    "table": "recipes",
    "attributes": {
      "id": 4,
      "title":"Chicken Burger",
      "num_steps": null,
      "chef_id": 2
    }
  }
]
```
(whitespace added for legibility)

```ruby
Polo.configure { use_translator Polo::SqlTranslator }
Polo.read(j)
```

will then produce:

```sql
INSERT INTO `chefs` (`id`, `name`) VALUES (2, 'Andrew')
INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`) VALUES (3, 'Vegemite Sandwich', NULL, 1)
INSERT INTO `recipes` (`id`, `title`, `num_steps`, `chef_id`) VALUES (4, 'Chicken Burger', NULL, 1)
```

# TODO
* Finalize naming/structure
* `JsonTranslator` to validate the format of the serialized input (perhaps through something like JSON Schema)
* Tests
* Documentation