### PR TITLE
Escape columns in DUPLICATE KEY statements

### DIFF
--- a/lib/polo/adapters/mysql.rb
+++ b/lib/polo/adapters/mysql.rb
@@ -5,7 +5,7 @@ module Polo
         insert_and_record = inserts.zip(records)
         insert_and_record.map do |insert, record|
           values_syntax = record.attributes.keys.map do |key|
-            "#{key} = VALUES(#{key})"
+            "`#{key}` = VALUES(`#{key}`)"
           end
 
           on_dup_syntax = "ON DUPLICATE KEY UPDATE #{values_syntax.join(', ')}"

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -29,7 +29,7 @@ describe Polo::Adapters::MySQL do
   describe '#on_duplicate_key_update' do
     it 'appends ON DUPLICATE KEY UPDATE with all values to the current INSERT statement' do
       insert_netto = [
-        %q{INSERT INTO "chefs" ("id", "name", "email") VALUES (1, 'Netto', 'nettofarah@gmail.com') ON DUPLICATE KEY UPDATE id = VALUES(id), name = VALUES(name), email = VALUES(email)}
+        %q{INSERT INTO "chefs" ("id", "name", "email") VALUES (1, 'Netto', 'nettofarah@gmail.com') ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `name` = VALUES(`name`), `email` = VALUES(`email`)}
       ]
 
       inserts = translator.inserts


### PR DESCRIPTION
I ran into this because I have a table with a column named `key`.   WDYT?