### PR TITLE
Fix Postgres adapter ignore_transform wrap ID in quotes for non-int/UUID

### DIFF
--- a/lib/polo/adapters/postgres.rb
+++ b/lib/polo/adapters/postgres.rb
@@ -24,7 +24,7 @@ module Polo
           table_name = record.class.arel_table.name
           id = record[:id]
           insert = insert.gsub(/VALUES \((.+)\)$/m, 'SELECT \\1')
-          insert << " WHERE NOT EXISTS (SELECT 1 FROM #{table_name} WHERE id=#{id});"
+          insert << " WHERE NOT EXISTS (SELECT 1 FROM \"#{table_name}\" WHERE id='#{id}');"
         end
       end
     end

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -23,7 +23,7 @@ describe Polo::Adapters::Postgres do
   describe '#ignore_transform' do
     it 'transforms INSERT by appending WHERE NOT EXISTS clause' do
 
-      insert_netto = [%q{INSERT INTO "chefs" ("id", "name", "email") SELECT 1, 'Netto', 'nettofarah@gmail.com' WHERE NOT EXISTS (SELECT 1 FROM chefs WHERE id=1);}]
+      insert_netto = [%q{INSERT INTO "chefs" ("id", "name", "email") SELECT 1, 'Netto', 'nettofarah@gmail.com' WHERE NOT EXISTS (SELECT 1 FROM "chefs" WHERE id='1');}]
 
       records = translator.records
       inserts = translator.inserts


### PR DESCRIPTION
Getting a Postgres (9.4.x) error when using 

```
Polo.configure do
  set_adapter :postgres
  on_duplicate :ignore
end
```

We're using UUID's, so @schultzy51 and I thought wrapping the ID in quotes would work for both UUID and Integers. He tested manually in `psql` and in `rails console`. I ran the specs locally using `2.2.3` instead of `2.2.5` but I assume that wouldn't be a problem.

Thanks in advance 👍 