### PR TITLE
Capture HABTM tables

### DIFF
--- a/lib/polo/adapters/mysql.rb
+++ b/lib/polo/adapters/mysql.rb
@@ -4,7 +4,8 @@ module Polo
       def on_duplicate_key_update(inserts, records)
         insert_and_record = inserts.zip(records)
         insert_and_record.map do |insert, record|
-          values_syntax = record.attributes.keys.map do |key|
+          attrs = record.is_a?(Hash) ? record.fetch(:values) : record.attributes
+          values_syntax = attrs.keys.map do |key|
             "`#{key}` = VALUES(`#{key}`)"
           end
 

--- a/lib/polo/adapters/postgres.rb
+++ b/lib/polo/adapters/postgres.rb
@@ -21,8 +21,13 @@ module Polo
       def ignore_transform(inserts, records)
         insert_and_record = inserts.zip(records)
         insert_and_record.map do |insert, record|
-          table_name = record.class.arel_table.name
-          id = record[:id]
+          if record.is_a?(Hash)
+            id = record.fetch(:values)[:id]
+            table_name = record.fetch(:table_name)
+          else
+            id = record[:id]
+            table_name = record.class.arel_table.name
+          end
           insert = insert.gsub(/VALUES \((.+)\)$/m, 'SELECT \\1')
           insert << " WHERE NOT EXISTS (SELECT 1 FROM #{table_name} WHERE id=#{id});"
         end

--- a/lib/polo/sql_translator.rb
+++ b/lib/polo/sql_translator.rb
@@ -36,7 +36,11 @@ module Polo
 
     def inserts
       records.map do |record|
-        raw_sql(record)
+        if record.is_a?(Hash)
+          raw_sql_from_hash(record)
+        else
+          raw_sql_from_record(record)
+        end
       end
     end
 
@@ -47,10 +51,20 @@ module Polo
     # It will make use of the InsertManager class from the Arel gem to generate
     # insert statements
     #
-    def raw_sql(record)
+    def raw_sql_from_record(record)
       record.class.arel_table.create_insert.tap do |insert_manager|
         insert_manager.insert(insert_values(record))
       end.to_sql
+    end
+
+    # Internal: Generates an insert SQL statement from a hash of values
+    def raw_sql_from_hash(hash)
+      connection = ActiveRecord::Base.connection
+      attributes = hash.fetch(:values)
+      table_name = connection.quote_table_name(hash.fetch(:table_name))
+      columns = attributes.keys.map{|k| connection.quote_column_name(k)}.join(", ")
+      value_placeholders = attributes.values.map{|v| "?" }.join(", ")
+      ActiveRecord::Base.send(:sanitize_sql_array, ["INSERT INTO #{table_name} (#{columns}) VALUES (#{value_placeholders})", *attributes.values])
     end
 
     # Internal: Returns an object's attribute definitions along with
@@ -88,7 +102,7 @@ module Polo
     #
     module ActiveRecordFivePointZeroOrOne
       # Based on the codepath used in Rails 5
-      def raw_sql(record)
+      def raw_sql_from_record(record)
         values = record.send(:arel_attributes_with_values_for_create, record.class.column_names)
         model = record.class
         substitutes, binds = model.unscoped.substitute_values(values)
@@ -105,7 +119,7 @@ module Polo
     # Internal: Returns an object's attribute definitions along with
     # their set values (for Rails >= 5.2).
     module ActiveRecordFive
-      def raw_sql(record)
+      def raw_sql_from_record(record)
         values = record.send(:attributes_with_values_for_create, record.class.column_names)
         model = record.class
         substitutes_and_binds = model.send(:_substitute_values, values)

--- a/spec/adapters/mysql_spec.rb
+++ b/spec/adapters/mysql_spec.rb
@@ -37,5 +37,15 @@ describe Polo::Adapters::MySQL do
       translated_sql = adapter.on_duplicate_key_update(inserts, records)
       expect(translated_sql).to eq(insert_netto)
     end
+    it 'works for hash-values instead of ActiveRecord instances' do
+      insert_netto = [
+        %q{INSERT INTO "chefs" ("id", "name", "email") VALUES (1, 'Netto', 'nettofarah@gmail.com') ON DUPLICATE KEY UPDATE `id` = VALUES(`id`), `name` = VALUES(`name`), `email` = VALUES(`email`)}
+      ]
+
+      inserts = translator.inserts
+      records = [{table_name: "chefs", values: { id: 1, name: "Netto", email: "nettofarah@gmail.com"}}]
+      translated_sql = adapter.on_duplicate_key_update(inserts, records)
+      expect(translated_sql).to eq(insert_netto)
+    end
   end
 end

--- a/spec/adapters/postgres_spec.rb
+++ b/spec/adapters/postgres_spec.rb
@@ -30,5 +30,14 @@ describe Polo::Adapters::Postgres do
       translated_sql = adapter.ignore_transform(inserts, records)
       expect(translated_sql).to eq(insert_netto)
     end
+
+    it 'works for hash-values instead of ActiveRecord instances' do
+      insert_netto = [%q{INSERT INTO "chefs" ("id", "name", "email") SELECT 1, 'Netto', 'nettofarah@gmail.com' WHERE NOT EXISTS (SELECT 1 FROM chefs WHERE id=1);}]
+
+      inserts = translator.inserts
+      records = [{table_name: "chefs", values: { id: 1, name: "Netto", email: "nettofarah@gmail.com"}}]
+      translated_sql = adapter.ignore_transform(inserts, records)
+      expect(translated_sql).to eq(insert_netto)
+    end
   end
 end

--- a/spec/polo_spec.rb
+++ b/spec/polo_spec.rb
@@ -48,6 +48,21 @@ describe Polo do
     expect(inserts).to include(two_cheeses)
   end
 
+  it 'generates inserts for HABTM relationships' do
+    ar_version = ActiveRecord::VERSION::STRING
+    skip("Not supported on ActiveRecord #{ar_version}") if ar_version < "4.1.0"
+    habtm_inserts = [
+      %q{INSERT INTO "recipes_tags" ("recipe_id", "tag_id") VALUES (2, 2)},
+      %q{INSERT INTO "tags" ("id", "name") VALUES (2, 'burgers')}
+    ]
+
+    inserts = Polo.explore(AR::Chef, 1, :recipes => :tags)
+
+    habtm_inserts.each do |habtm_insert|
+      expect(inserts).to include(habtm_insert)
+    end
+  end
+
   it 'generates inserts for many to many relationships' do
     many_to_many_inserts = [
       %q{INSERT INTO "recipes_ingredients" ("id", "recipe_id", "ingredient_id") VALUES (1, 1, 1)},

--- a/spec/support/activerecord_models.rb
+++ b/spec/support/activerecord_models.rb
@@ -3,11 +3,16 @@ module AR
     belongs_to :chef
     has_many :recipes_ingredients
     has_many :ingredients, through: :recipes_ingredients
+    has_and_belongs_to_many :tags
 
     serialize :metadata, JSON
   end
 
   class Ingredient < ActiveRecord::Base
+  end
+
+  class Tag < ActiveRecord::Base
+    has_and_belongs_to_many :recipes
   end
 
   class RecipesIngredient < ActiveRecord::Base

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -5,11 +5,13 @@ module TestData
       AR::Recipe.create(title: 'Turkey Sandwich', chef: netto).tap do |r|
         r.ingredients.create(name: 'Turkey', quantity: 'a lot')
         r.ingredients.create(name: 'Cheese', quantity: '1 slice')
+        r.tags.create(name: 'sandwiches')
       end
 
       AR::Recipe.create(title: 'Cheese Burger', chef: netto).tap do |r|
         r.ingredients.create(name: 'Patty', quantity: '1')
         r.ingredients.create(name: 'Cheese', quantity: '2 slices')
+        r.tags.create(name: 'burgers')
       end
     end
 

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -39,4 +39,13 @@ ActiveRecord::Schema.define do
   create_table :employees, force: true do |t|
     t.column :name, :string
   end
+
+  create_table :tags, force: true do |t|
+    t.column :name, :string
+  end
+
+  create_table :recipes_tags, id: false, force: true do |t|
+    t.column :recipe_id, :integer
+    t.column :tag_id, :integer
+  end
 end


### PR DESCRIPTION
This is a POC for capturing HABTM relationships (see #38).  This feels a bit hacky, but I'm struggling to figure out a non-hacky way.

`Translator#instances` used to return an array of ActiveRecord objects.   It now returns an array of objects, some of which are AR objects, some of which are hashes like `{table_name: "recipes_tags", values: {recipe_id: 1, tag_id: 2}}`.

It only works on Rails 4.1 or above.  In Rails 4.0 and below, the HABTM records are loaded via an inner join which is too hard for me to deal with 😕 .

WDYT?