### PR TITLE
Omits attributes not backed by a database column

### DIFF
--- a/lib/polo/sql_translator.rb
+++ b/lib/polo/sql_translator.rb
@@ -89,7 +89,7 @@ module Polo
     module ActiveRecordFive
       # Based on the codepath used in Rails 5
       def raw_sql(record)
-        values = record.send(:arel_attributes_with_values_for_create, record.attribute_names)
+        values = record.send(:arel_attributes_with_values_for_create, record.class.column_names)
         model = record.class
         substitutes, binds = model.unscoped.substitute_values(values)
 

--- a/spec/sql_translator_spec.rb
+++ b/spec/sql_translator_spec.rb
@@ -21,4 +21,10 @@ describe Polo::SqlTranslator do
     recipe_to_sql = Polo::SqlTranslator.new(recipe).to_sql.first
     expect(recipe_to_sql).to include(%q{'{"quality":"ok"}'}) # JSON, not YAML
   end
+
+  it 'encodes attributes not backed by a database column correctly' do
+    recipe = AR::Employee.create(name: 'John Doe', on_vacation: true)
+    recipe_to_sql = Polo::SqlTranslator.new(recipe).to_sql.first
+    expect(recipe_to_sql).to_not include('on_vacation')
+  end
 end

--- a/spec/support/activerecord_models.rb
+++ b/spec/support/activerecord_models.rb
@@ -30,6 +30,10 @@ module AR
     has_one  :restaurant, foreign_key: 'owner_id'
   end
 
+  class Employee < ActiveRecord::Base
+    attribute :on_vacation
+  end
+
   class Person < ActiveRecord::Base
     self.primary_key = :ssn
   end

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -35,4 +35,8 @@ ActiveRecord::Schema.define do
   create_table :people, primary_key: :ssn, force: true do |t|
     t.column :name, :string
   end
+
+  create_table :employees, force: true do |t|
+    t.column :name, :string
+  end
 end


### PR DESCRIPTION
The purpose of this PR is to make sure that ActiveRecord attributes that don't have a column are not included in the column names of the insert statements generated by SqlTranslator.